### PR TITLE
Validate texture stage index

### DIFF
--- a/include/dx8gles11.h
+++ b/include/dx8gles11.h
@@ -25,6 +25,11 @@ typedef enum gles_cmd_type {
     GLES_CMD_MATRIX_LOAD,
     GLES_CMD_LOAD_IDENTITY,
     GLES_CMD_LIGHT_PARAM,
+    /*
+     * Emitted when the translator encounters an unsupported opcode or
+     * invalid operand. For example, "mov oT8, r0" produces this command and
+     * sets an error via dx8gles11_error().
+     */
     GLES_CMD_UNKNOWN
 } gles_cmd_type;
 

--- a/src/dx8_to_gles11.c
+++ b/src/dx8_to_gles11.c
@@ -88,6 +88,11 @@ static void xlate(const asm_instr *i, GLES_CommandList *o) {
     }
 
     if (!strcmp(i->opcode, "mov") && !strncmp(i->dst, "oT", 2)) {
+        if (i->dst[2] < '0' || i->dst[2] > '7') {
+            set_err("texture stage must be 0..7: %s", i->dst);
+            cl_push(o, (gles_cmd){.type = GLES_CMD_UNKNOWN});
+            return;
+        }
         unsigned stage = (unsigned)(i->dst[2] - '0');
         gles_cmd c = {.type = GLES_CMD_MULTITEXCOORD4F};
         c.u[0] = GL_TEXTURE0 + stage;


### PR DESCRIPTION
## Summary
- catch invalid oT stage numbers in `xlate`
- emit `GLES_CMD_UNKNOWN` and store an error
- document invalid stage behaviour

## Testing
- `ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_6855df785fe08325be561a38b3f3120a