### PR TITLE
Fix texture combine setup in example runtime

### DIFF
--- a/examples/replay_runtime.c
+++ b/examples/replay_runtime.c
@@ -12,7 +12,14 @@ static void execute_cmds(const GLES_CommandList *cl) {
             glEnableClientState(GL_COLOR_ARRAY);
             break;
         case GLES_CMD_TEX_ENV_COMBINE:
-            glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, c->u[1]);
+            /*
+             * c->u[0] holds the desired texture env mode (GL_COMBINE).
+             * c->u[1] selects the combine function, reused for both RGB
+             * and ALPHA channels.
+             */
+            glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, c->u[0]);
+            glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, c->u[1]);
+            glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, c->u[1]);
             break;
         case GLES_CMD_MULTITEXCOORD4F:
             glClientActiveTexture(c->u[0]);

--- a/include/dx8gles11.h
+++ b/include/dx8gles11.h
@@ -25,6 +25,11 @@ typedef enum gles_cmd_type {
     GLES_CMD_MATRIX_LOAD,
     GLES_CMD_LOAD_IDENTITY,
     GLES_CMD_LIGHT_PARAM,
+    /*
+     * Emitted when the translator encounters an unsupported opcode or
+     * invalid operand. For example, "mov oT8, r0" produces this command and
+     * sets an error via dx8gles11_error().
+     */
     GLES_CMD_UNKNOWN
 } gles_cmd_type;
 

--- a/src/dx8_to_gles11.c
+++ b/src/dx8_to_gles11.c
@@ -88,6 +88,11 @@ static void xlate(const asm_instr *i, GLES_CommandList *o) {
     }
 
     if (!strcmp(i->opcode, "mov") && !strncmp(i->dst, "oT", 2)) {
+        if (i->dst[2] < '0' || i->dst[2] > '7') {
+            set_err("texture stage must be 0..7: %s", i->dst);
+            cl_push(o, (gles_cmd){.type = GLES_CMD_UNKNOWN});
+            return;
+        }
         unsigned stage = (unsigned)(i->dst[2] - '0');
         gles_cmd c = {.type = GLES_CMD_MULTITEXCOORD4F};
         c.u[0] = GL_TEXTURE0 + stage;


### PR DESCRIPTION
## Summary
- set texture environment mode before configuring combine function
- apply combine function to both RGB and ALPHA channels

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`
- `ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_6855e8c6002483258ff6f7b02c3e7cae