### PR TITLE
Add dx8gles11_compile_string API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ if (dx8gles11_compile_file("shader.asm", NULL, &cl) != 0) {
     exit(1);
 }
 
+/* alternatively: dx8gles11_compile_string(src_text, NULL, &cl); */
+
 for (size_t i = 0; i < cl.count; ++i) {
     const gles_cmd *c = &cl.data[i];
     /* switch (c->type) → issue gl* calls */
@@ -85,6 +87,10 @@ for (size_t i = 0; i < cl.count; ++i) {
 
 gles_cmdlist_free(&cl);
 ```
+
+If the assembly text is already in memory, call `dx8gles11_compile_string()`
+instead of `dx8gles11_compile_file()`. The string is consumed as-is with no
+`#include` processing.
 
 A reference executor (`examples/replay_runtime.c`) is planned for v0.2.
 

--- a/include/dx8gles11.h
+++ b/include/dx8gles11.h
@@ -42,6 +42,7 @@ typedef struct GLES_CommandList {
 
 /* API ----------------------------------------------------------- */
 int dx8gles11_compile_file(const char *path, const dx8gles11_options *opts, GLES_CommandList *out);
+int dx8gles11_compile_string(const char *src, const dx8gles11_options *opts, GLES_CommandList *out);
 const char *dx8gles11_error(void);
 void gles_cmdlist_free(GLES_CommandList *);
 

--- a/src/dx8_to_gles11.c
+++ b/src/dx8_to_gles11.c
@@ -99,6 +99,35 @@ static void xlate(const asm_instr *i, GLES_CommandList *o) {
     cl_push(o, (gles_cmd){.type = GLES_CMD_UNKNOWN});
 }
 
+/* shared compilation logic for string and file paths */
+static int compile_from_source(const char *src, GLES_CommandList *out) {
+    asm_program prog = {0};
+    if (asm_parse(src, &prog, NULL)) {
+        set_err("parse error");
+        return -1;
+    }
+    for (size_t idx = 0; idx < prog.count; ++idx)
+        xlate(&prog.code[idx], out);
+
+    asm_program_free(&prog);
+    return 0;
+}
+
+int dx8gles11_compile_string(const char *src, const dx8gles11_options *opt,
+                             GLES_CommandList *out) {
+    (void)opt;
+    if (!src) {
+        set_err("source null");
+        return -1;
+    }
+    if (!out) {
+        set_err("out list null");
+        return -1;
+    }
+    cl_init(out);
+    return compile_from_source(src, out);
+}
+
 int dx8gles11_compile_file(const char *path, const dx8gles11_options *opt, GLES_CommandList *out) {
     if (!out) {
         set_err("out list null");
@@ -114,16 +143,9 @@ int dx8gles11_compile_file(const char *path, const dx8gles11_options *opt, GLES_
         return -2;
     }
 
-    asm_program prog = {0};
-    if (asm_parse(src, &prog, NULL)) {
-        set_err("parse error");
-        free(src);
-        return -3;
-    }
-    for (size_t idx = 0; idx < prog.count; ++idx)
-        xlate(&prog.code[idx], out);
-
-    asm_program_free(&prog);
+    int r = compile_from_source(src, out);
     free(src);
+    if (r != 0)
+        return -3;
     return 0;
 }


### PR DESCRIPTION
## Summary
- introduce `dx8gles11_compile_string()` to compile from in-memory strings
- refactor common compile logic to avoid duplication
- document new function in README

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_6855e8cbb1988325bc47bda9dd056b0f