### PR TITLE
Add TEX_ENVF case to example runtime

### DIFF
--- a/examples/replay_runtime.c
+++ b/examples/replay_runtime.c
@@ -11,6 +11,13 @@ static void execute_cmds(const GLES_CommandList *cl) {
             /* pass-through – bind vertex colour array */
             glEnableClientState(GL_COLOR_ARRAY);
             break;
+        case GLES_CMD_TEX_ENVF:
+            /*
+             * c->u[0] maps to the pname argument of glTexEnvf.
+             * c->f[0] provides the float parameter value.
+             */
+            glTexEnvf(GL_TEXTURE_ENV, c->u[0], c->f[0]);
+            break;
         case GLES_CMD_TEX_ENV_COMBINE:
             /*
              * c->u[0] holds the desired texture env mode (GL_COMBINE).


### PR DESCRIPTION
## Summary
- extend `examples/replay_runtime.c` to interpret `GLES_CMD_TEX_ENVF`
- map command data to `glTexEnvf`

## Testing
- `cmake -S . -B build -DBUILD_EXAMPLES=ON`
- `cmake --build build`
- `cd build && ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_6856d039150883258ae7faf82b8f0a5e