### PR TITLE
Add util_strdup helper for portability

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -31,6 +31,7 @@ static inline size_t *sb__raw(void *a) { return (size_t *)((char *)a - sizeof(si
     } while (0)
 
 char *util_strndup(const char *s, size_t n);
+char *util_strdup(const char *s);
 int util_vasprintf(char **out, const char *fmt, va_list ap);
 int util_asprintf(char **out, const char *fmt, ...);
 

--- a/src/preprocess.c
+++ b/src/preprocess.c
@@ -69,7 +69,7 @@ static char *subst_macros(const char *line, macro *macros) {
         }
     }
     if (!out) {
-        out = strdup("");
+        out = util_strdup("");
     } else {
         out[out_len] = '\0';
     }
@@ -83,7 +83,7 @@ static char *path_dir(const char *path) {
         slash = bslash;
 #endif
     if (!slash)
-        return strdup(".");
+        return util_strdup(".");
     return util_strndup(path, (size_t)(slash - path));
 }
 
@@ -160,7 +160,7 @@ static char *process(const char *src_path, const char *src, const char *inc_dir,
                     ++trim;
                 char *name = util_strndup(ns, trim - ns);
                 trim = skip_ws(trim);
-                char *val = strdup(trim);
+                char *val = util_strdup(trim);
                 macro m = {name, val};
                 sb_push(macros, m);
             }
@@ -189,7 +189,7 @@ static char *process(const char *src_path, const char *src, const char *inc_dir,
 char *pp_run(const char *src_p, const char *inc_dir, char **err) {
     char *s = read_file(src_p);
     if (!s) {
-        *err = strdup("Could not read source file");
+        *err = util_strdup("Could not read source file");
         return NULL;
     }
     char *dir = path_dir(src_p);

--- a/src/utils.c
+++ b/src/utils.c
@@ -15,6 +15,8 @@ char *util_strndup(const char *s, size_t n) {
     return out;
 }
 
+char *util_strdup(const char *s) { return util_strndup(s, strlen(s)); }
+
 int util_vasprintf(char **out, const char *fmt, va_list ap) {
     va_list ap2;
     va_copy(ap2, ap);


### PR DESCRIPTION
## Summary
- add `util_strdup` implementation
- replace direct uses of `strdup` with `util_strdup`

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest -V`


------
https://chatgpt.com/codex/tasks/task_e_6856d8250198832588d1c0e1b8414472