### PR TITLE
Add simple threading benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(BUILD_EXAMPLES "Build replay_runtime example" ON)
+option(BUILD_BENCHMARKS "Build benchmark tools" ON)
 enable_testing()
 
 add_library(dx8gles11 STATIC
@@ -63,6 +64,14 @@ if(BUILD_EXAMPLES)
         find_package(OpenGL REQUIRED)
         target_link_libraries(replay_runtime OpenGL::GL)
     endif()
+endif()
+
+if(BUILD_BENCHMARKS)
+    find_package(Threads REQUIRED)
+    add_executable(bench_translate
+        tools/bench_translate.c
+        src/minithread.c)
+    target_link_libraries(bench_translate dx8gles11 Threads::Threads)
 endif()
 
 enable_testing()

--- a/include/minithread.h
+++ b/include/minithread.h
@@ -1,0 +1,31 @@
+#ifndef DX8GLES11_MINITHREAD_H
+#define DX8GLES11_MINITHREAD_H
+
+#include <threads.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct mt_task;
+typedef struct mt_pool {
+  thrd_t *threads;
+  int num_threads;
+  mtx_t mtx;
+  cnd_t cv;
+  struct mt_task *head;
+  struct mt_task *tail;
+  int stop;
+  int active;
+} mt_pool;
+
+int mt_pool_init(mt_pool *p, int num_threads);
+void mt_pool_destroy(mt_pool *p);
+int mt_pool_submit(mt_pool *p, void (*func)(void *), void *arg);
+void mt_pool_join(mt_pool *p);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DX8GLES11_MINITHREAD_H */

--- a/src/dx8_to_gles11.c
+++ b/src/dx8_to_gles11.c
@@ -10,7 +10,7 @@
 #include <GLES/gl.h>
 #include <GLES/glext.h>
 
-static char g_err[256] = "";
+static _Thread_local char g_err[256] = "";
 static void set_err(const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);

--- a/src/minithread.c
+++ b/src/minithread.c
@@ -1,0 +1,93 @@
+#include "minithread.h"
+#include <stdlib.h>
+
+struct mt_task {
+  void (*func)(void *);
+  void *arg;
+  struct mt_task *next;
+};
+
+static int worker(void *arg) {
+  mt_pool *p = arg;
+  for (;;) {
+    mtx_lock(&p->mtx);
+    while (!p->head && !p->stop)
+      cnd_wait(&p->cv, &p->mtx);
+    if (p->stop && !p->head) {
+      mtx_unlock(&p->mtx);
+      break;
+    }
+    struct mt_task *t = p->head;
+    p->head = t->next;
+    if (!p->head)
+      p->tail = NULL;
+    p->active++;
+    mtx_unlock(&p->mtx);
+
+    t->func(t->arg);
+    free(t);
+
+    mtx_lock(&p->mtx);
+    p->active--;
+    if (!p->head && p->active == 0)
+      cnd_broadcast(&p->cv);
+    mtx_unlock(&p->mtx);
+  }
+  return 0;
+}
+
+int mt_pool_init(mt_pool *p, int n) {
+  if (n <= 0)
+    n = 1;
+  p->threads = calloc((size_t)n, sizeof(thrd_t));
+  if (!p->threads)
+    return -1;
+  p->num_threads = n;
+  p->head = p->tail = NULL;
+  p->stop = 0;
+  p->active = 0;
+  if (mtx_init(&p->mtx, mtx_plain) != thrd_success)
+    return -1;
+  if (cnd_init(&p->cv) != thrd_success)
+    return -1;
+  for (int i = 0; i < n; ++i)
+    thrd_create(&p->threads[i], worker, p);
+  return 0;
+}
+
+void mt_pool_destroy(mt_pool *p) {
+  mtx_lock(&p->mtx);
+  p->stop = 1;
+  cnd_broadcast(&p->cv);
+  mtx_unlock(&p->mtx);
+  for (int i = 0; i < p->num_threads; ++i)
+    thrd_join(p->threads[i], NULL);
+  free(p->threads);
+  mtx_destroy(&p->mtx);
+  cnd_destroy(&p->cv);
+}
+
+int mt_pool_submit(mt_pool *p, void (*func)(void *), void *arg) {
+  struct mt_task *t = malloc(sizeof(*t));
+  if (!t)
+    return -1;
+  t->func = func;
+  t->arg = arg;
+  t->next = NULL;
+  mtx_lock(&p->mtx);
+  if (p->tail)
+    p->tail->next = t;
+  else
+    p->head = t;
+  p->tail = t;
+  cnd_signal(&p->cv);
+  mtx_unlock(&p->mtx);
+  return 0;
+}
+
+void mt_pool_join(mt_pool *p) {
+  mtx_lock(&p->mtx);
+  while (p->head || p->active)
+    cnd_wait(&p->cv, &p->mtx);
+  mtx_unlock(&p->mtx);
+}

--- a/tools/bench_translate.c
+++ b/tools/bench_translate.c
@@ -1,0 +1,75 @@
+#include "dx8gles11.h"
+#include "minithread.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+static char *read_file(const char *path) {
+  FILE *f = fopen(path, "rb");
+  if (!f)
+    return NULL;
+  fseek(f, 0, SEEK_END);
+  long n = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  char *buf = malloc((size_t)n + 1);
+  if (!buf) {
+    fclose(f);
+    return NULL;
+  }
+  if (fread(buf, 1, (size_t)n, f) != (size_t)n) {
+    fclose(f);
+    free(buf);
+    return NULL;
+  }
+  fclose(f);
+  buf[n] = '\0';
+  return buf;
+}
+
+static void compile_task(void *arg) {
+  const char *src = arg;
+  GLES_CommandList cl;
+  dx8gles11_compile_string(src, NULL, &cl);
+  gles_cmdlist_free(&cl);
+}
+
+static double bench_serial(const char *src, int iters) {
+  struct timespec s, e;
+  clock_gettime(CLOCK_MONOTONIC, &s);
+  for (int i = 0; i < iters; ++i)
+    compile_task((void *)src);
+  clock_gettime(CLOCK_MONOTONIC, &e);
+  return (e.tv_sec - s.tv_sec) * 1000.0 + (e.tv_nsec - s.tv_nsec) / 1e6;
+}
+
+static double bench_threaded(const char *src, int iters, int threads) {
+  mt_pool p;
+  mt_pool_init(&p, threads);
+  struct timespec s, e;
+  clock_gettime(CLOCK_MONOTONIC, &s);
+  for (int i = 0; i < iters; ++i)
+    mt_pool_submit(&p, compile_task, (void *)src);
+  mt_pool_join(&p);
+  clock_gettime(CLOCK_MONOTONIC, &e);
+  mt_pool_destroy(&p);
+  return (e.tv_sec - s.tv_sec) * 1000.0 + (e.tv_nsec - s.tv_nsec) / 1e6;
+}
+
+int main(int argc, char **argv) {
+  const char *path = argc > 1 ? argv[1] : "../tests/fixtures/matrix_ops.asm";
+  int iters = argc > 2 ? atoi(argv[2]) : 100;
+  int threads = argc > 3 ? atoi(argv[3]) : 4;
+  char *src = read_file(path);
+  if (!src) {
+    fprintf(stderr, "failed to read %s\n", path);
+    return 1;
+  }
+  double t_serial = bench_serial(src, iters);
+  double t_thread = bench_threaded(src, iters, threads);
+  printf(
+      "Iterations: %d\nSerial time: %.2f ms\nThreaded (%d threads): %.2f ms\n",
+      iters, t_serial, threads, t_thread);
+  free(src);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add an optional mini thread pool implementation
- expose the pool via new `minithread.h`
- add `bench_translate` tool to compare single vs multi-threaded compilation
- allow building benchmarks via `BUILD_BENCHMARKS` option
- make error buffer thread-local for concurrency

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest -V`
- `./bench_translate`

------
https://chatgpt.com/codex/tasks/task_e_6856db0cd094832591196a9efd2082f3