### PR TITLE
Add ps.1.3 profile support

### DIFF
--- a/include/dx8asm_parser.h
+++ b/include/dx8asm_parser.h
@@ -9,6 +9,7 @@ typedef struct asm_instr {
 typedef enum asm_shader_type {
     ASM_SHADER_NONE,
     ASM_SHADER_PS11,
+    ASM_SHADER_PS13,
     ASM_SHADER_VS11
 } asm_shader_type;
 

--- a/src/dx8_to_gles11.c
+++ b/src/dx8_to_gles11.c
@@ -237,6 +237,18 @@ static int validate_shader(const asm_program *p) {
             set_err("ps.1.1 allows max 4 tex and 8 arithmetic instructions");
             return -1;
         }
+    } else if (p->type == ASM_SHADER_PS13) {
+        size_t tex = 0, arith = 0;
+        for (size_t i = 0; i < p->count; ++i) {
+            if (!strncmp(p->code[i].opcode, "tex", 3))
+                ++tex;
+            else
+                ++arith;
+        }
+        if (tex > 4 || arith > 12) {
+            set_err("ps.1.3 allows max 4 tex and 12 arithmetic instructions");
+            return -1;
+        }
     } else if (p->type == ASM_SHADER_VS11) {
         if (p->count > 128) {
             set_err("vs.1.1 allows max 128 instructions");

--- a/src/dx8asm_parser.c
+++ b/src/dx8asm_parser.c
@@ -55,6 +55,11 @@ int asm_parse(const char *src, asm_program *prog, char **err) {
             free(buf);
             continue;
         }
+        if (!strcmp(trim, "ps.1.3")) {
+            prog->type = ASM_SHADER_PS13;
+            free(buf);
+            continue;
+        }
         if (!strcmp(trim, "vs.1.1")) {
             prog->type = ASM_SHADER_VS11;
             free(buf);

--- a/tests/test_compile_limits.c
+++ b/tests/test_compile_limits.c
@@ -46,5 +46,34 @@ int main(void) {
         fprintf(stderr, "bad vs error: %s\n", dx8gles11_error());
         return 1;
     }
+
+    const char *ps13_src =
+        "ps.1.3\n"
+        "tex t0\n"
+        "tex t1\n"
+        "tex t2\n"
+        "tex t3\n"
+        "nop\n"  /* 1 */
+        "nop\n"  /* 2 */
+        "nop\n"  /* 3 */
+        "nop\n"  /* 4 */
+        "nop\n"  /* 5 */
+        "nop\n"  /* 6 */
+        "nop\n"  /* 7 */
+        "nop\n"  /* 8 */
+        "nop\n"  /* 9 */
+        "nop\n"  /*10*/
+        "nop\n"  /*11*/
+        "nop\n"  /*12*/
+        "nop\n"; /*13th arithmetic*/
+    if (dx8gles11_compile_string(ps13_src, NULL, &cl) == 0) {
+        fprintf(stderr, "ps1.3 limit not enforced\n");
+        gles_cmdlist_free(&cl);
+        return 1;
+    }
+    if (!strstr(dx8gles11_error(), "ps.1.3")) {
+        fprintf(stderr, "bad ps1.3 error: %s\n", dx8gles11_error());
+        return 1;
+    }
     return 0;
 }


### PR DESCRIPTION
## Summary
- add `ASM_SHADER_PS13` shader type
- detect `ps.1.3` in the parser
- allow up to 4 texture and 12 arithmetic instructions for ps.1.3
- test compile limits for the new profile

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_685720ab20e08325bed1be1e627e8edd