### PR TITLE
Increase opcode buffer length

### DIFF
--- a/include/dx8asm_parser.h
+++ b/include/dx8asm_parser.h
@@ -3,7 +3,8 @@
 #include <stddef.h>
 
 typedef struct asm_instr {
-    char opcode[8], dst[32], src0[32], src1[32], src2[32];
+    /* opcode buffer must hold instructions like "texbeml" or longer */
+    char opcode[16], dst[32], src0[32], src1[32], src2[32];
 } asm_instr;
 
 typedef enum asm_shader_type {

--- a/src/dx8asm_parser.c
+++ b/src/dx8asm_parser.c
@@ -84,7 +84,7 @@ int asm_parse(const char *src, asm_program *prog, char **err) {
 
         asm_instr inst = {0};
         char operands[128] = "";
-        if (sscanf(trim, "%7s%127[^\n]", inst.opcode, operands) < 1) {
+        if (sscanf(trim, "%15s%127[^\n]", inst.opcode, operands) < 1) {
             if (err)
                 util_asprintf(err, "line %zu: invalid instruction: %s",
                               line - 1, trim);


### PR DESCRIPTION
## Summary
- enlarge `asm_instr.opcode` to 16 characters
- adjust sscanf width in the parser

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build -V`


------
https://chatgpt.com/codex/tasks/task_e_685721c2b1ac8325a55c1e37ebfa903a