### PR TITLE
Add extension helper and runtime check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,10 @@ if(BUILD_BENCHMARKS)
         tools/bench_translate.c
         src/minithread.c)
     target_link_libraries(bench_translate dx8gles11 Threads::Threads)
+    if(NOT EMSCRIPTEN)
+        find_package(OpenGL REQUIRED)
+        target_link_libraries(bench_translate OpenGL::GL)
+    endif()
 endif()
 
 enable_testing()

--- a/examples/replay_runtime.c
+++ b/examples/replay_runtime.c
@@ -2,6 +2,8 @@
 #include <stdio.h>
 
 #include <GLES/gl.h>
+#include <GLES/glext.h>
+#include <string.h>
 
 static void execute_cmds(const GLES_CommandList *cl) {
     for (size_t i = 0; i < cl->count; ++i) {
@@ -24,6 +26,11 @@ static void execute_cmds(const GLES_CommandList *cl) {
              * c->u[1] selects the combine function, reused for both RGB
              * and ALPHA channels.
              */
+            if ((c->u[1] == GL_MAX_EXT || c->u[1] == GL_MIN_EXT) &&
+                !dx8gles11_has_extension("GL_EXT_blend_minmax")) {
+                fprintf(stderr, "%s\n", dx8gles11_error());
+                return;
+            }
             glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, c->u[0]);
             glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, c->u[1]);
             glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, c->u[1]);

--- a/include/dx8gles11.h
+++ b/include/dx8gles11.h
@@ -55,6 +55,7 @@ int dx8gles11_compile_file(const char *path, const dx8gles11_options *opts, GLES
 int dx8gles11_compile_string(const char *src, const dx8gles11_options *opts, GLES_CommandList *out);
 const char *dx8gles11_error(void);
 void gles_cmdlist_free(GLES_CommandList *);
+int dx8gles11_has_extension(const char *name);
 
 #ifdef __cplusplus
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,21 +1,23 @@
+find_package(OpenGL REQUIRED)
+
 add_executable(test_preprocess test_preprocess.c)
-target_link_libraries(test_preprocess dx8gles11)
+target_link_libraries(test_preprocess dx8gles11 OpenGL::GL)
 add_test(NAME preprocess_nested_includes COMMAND test_preprocess
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(test_missing_include test_missing_include.c)
-target_link_libraries(test_missing_include dx8gles11)
+target_link_libraries(test_missing_include dx8gles11 OpenGL::GL)
 add_test(NAME preprocess_missing_include COMMAND test_missing_include
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(test_parse_error test_parse_error.c)
-target_link_libraries(test_parse_error dx8gles11)
+target_link_libraries(test_parse_error dx8gles11 OpenGL::GL)
 add_test(NAME parse_error_invalid_instr COMMAND test_parse_error fixtures/invalid_instr.asm
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME parse_error_invalid_const COMMAND test_parse_error fixtures/invalid_const.asm
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_executable(test_compile test_compile.c)
-target_link_libraries(test_compile dx8gles11)
+target_link_libraries(test_compile dx8gles11 OpenGL::GL)
 foreach(f mov_tex mul_const dp3_matrix add matrix_ops tex_ops terrain_ps motion_blur_vs
              river_water_ps water_reflection_ps water_trapezoid_ps max_min cnd nop
              ps13_ops)
@@ -26,7 +28,7 @@ foreach(f mov_tex mul_const dp3_matrix add matrix_ops tex_ops terrain_ps motion_
 endforeach()
 
 add_executable(test_compile_string test_compile_string.c)
-target_link_libraries(test_compile_string dx8gles11)
+target_link_libraries(test_compile_string dx8gles11 OpenGL::GL)
 add_test(NAME compile_string_vs
     COMMAND test_compile_string ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/compile_string_vs.asm
                                 ${CMAKE_CURRENT_SOURCE_DIR}/expected/compile_string_vs.txt
@@ -39,6 +41,6 @@ add_test(NAME compile_string_ps
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(test_compile_limits test_compile_limits.c)
-target_link_libraries(test_compile_limits dx8gles11)
+target_link_libraries(test_compile_limits dx8gles11 OpenGL::GL)
 add_test(NAME compile_limits COMMAND test_compile_limits
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
## Summary
- cache GL extension string and expose `dx8gles11_has_extension`
- check `GL_EXT_blend_minmax` before using `GL_MAX_EXT`/`GL_MIN_EXT`
- link tests and benchmarks with OpenGL

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_68572ced3c648325a979df53ac2b50ec