### PR TITLE
Add lock-free queue utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(dx8gles11 STATIC
     src/dx8asm_parser.c
     src/dx8_to_gles11.c
     src/utils.c
+    src/lf_queue.c
 )
 
 target_include_directories(dx8gles11 PUBLIC

--- a/include/lf_queue.h
+++ b/include/lf_queue.h
@@ -1,0 +1,29 @@
+#ifndef DX8GLES11_LF_QUEUE_H
+#define DX8GLES11_LF_QUEUE_H
+
+#include <stdatomic.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct lf_queue_node {
+    void *value;
+    struct lf_queue_node *next;
+} lf_queue_node;
+
+typedef struct lf_queue {
+    _Atomic(lf_queue_node *) head;
+    _Atomic(lf_queue_node *) tail;
+} lf_queue;
+
+int lf_queue_init(lf_queue *q);
+void lf_queue_destroy(lf_queue *q);
+int lf_queue_push(lf_queue *q, void *value);
+void *lf_queue_pop(lf_queue *q);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DX8GLES11_LF_QUEUE_H */

--- a/src/lf_queue.c
+++ b/src/lf_queue.c
@@ -1,0 +1,73 @@
+#include "lf_queue.h"
+#include <stdlib.h>
+
+int lf_queue_init(lf_queue *q) {
+    lf_queue_node *n = malloc(sizeof(*n));
+    if (!n)
+        return -1;
+    n->next = NULL;
+    n->value = NULL;
+    atomic_store(&q->head, n);
+    atomic_store(&q->tail, n);
+    return 0;
+}
+
+void lf_queue_destroy(lf_queue *q) {
+    lf_queue_node *n = atomic_load(&q->head);
+    while (n) {
+        lf_queue_node *next = n->next;
+        free(n);
+        n = next;
+    }
+}
+
+int lf_queue_push(lf_queue *q, void *value) {
+    lf_queue_node *n = malloc(sizeof(*n));
+    if (!n)
+        return -1;
+    n->value = value;
+    n->next = NULL;
+
+    for (;;) {
+        lf_queue_node *tail = atomic_load_explicit(&q->tail, memory_order_acquire);
+        lf_queue_node *next = atomic_load_explicit(&tail->next, memory_order_acquire);
+        if (next == NULL) {
+            if (atomic_compare_exchange_weak_explicit(&tail->next, &next, n,
+                                                      memory_order_release,
+                                                      memory_order_relaxed)) {
+                atomic_compare_exchange_weak_explicit(&q->tail, &tail, n,
+                                                      memory_order_release,
+                                                      memory_order_relaxed);
+                return 0;
+            }
+        } else {
+            atomic_compare_exchange_weak_explicit(&q->tail, &tail, next,
+                                                  memory_order_release,
+                                                  memory_order_relaxed);
+        }
+    }
+}
+
+void *lf_queue_pop(lf_queue *q) {
+    for (;;) {
+        lf_queue_node *head = atomic_load_explicit(&q->head, memory_order_acquire);
+        lf_queue_node *tail = atomic_load_explicit(&q->tail, memory_order_acquire);
+        lf_queue_node *next = atomic_load_explicit(&head->next, memory_order_acquire);
+        if (head == tail) {
+            if (next == NULL)
+                return NULL;
+            atomic_compare_exchange_weak_explicit(&q->tail, &tail, next,
+                                                  memory_order_release,
+                                                  memory_order_relaxed);
+        } else {
+            void *value = next->value;
+            if (atomic_compare_exchange_weak_explicit(&q->head, &head, next,
+                                                      memory_order_release,
+                                                      memory_order_relaxed)) {
+                free(head);
+                return value;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add new `lf_queue` header exposing init/destroy/push/pop
- implement lock-free queue using C11 atomics
- compile new source via CMake

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest -V`


------
https://chatgpt.com/codex/tasks/task_e_6857385440a083259c28d9cc4b9d7fc0