### PR TITLE
Add runtime pipeline example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,11 @@ install(
 )
 
 if(BUILD_EXAMPLES)
-    add_executable(replay_runtime examples/replay_runtime.c)
-    target_link_libraries(replay_runtime dx8gles11)
+    find_package(Threads REQUIRED)
+    add_executable(replay_runtime
+        examples/replay_runtime.c
+        src/minithread.c)
+    target_link_libraries(replay_runtime dx8gles11 Threads::Threads)
     if(NOT EMSCRIPTEN)
         find_package(OpenGL REQUIRED)
         target_link_libraries(replay_runtime OpenGL::GL)


### PR DESCRIPTION
## Summary
- build `replay_runtime` with `minithread.c`
- implement a `read_file` helper for example
- run the new runtime pipeline with optional thread count

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`
- `cd build && ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_685744dde7108325bf9004868dab4e26