### PR TITLE
Add host-aware throughput benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ For higher throughput you can process shaders with the optional multi-threaded p
 2. **Prepare** – convert each instruction into `gles_cmd` entries via `translate_instr()`.
 3. **Dispatch** – execute the resulting commands on the GL driver.
 
-Use `pipeline_init(&p, threads)` and `pipeline_start(&p)` to begin processing. When done, call `pipeline_stop(&p)` followed by `pipeline_join(&p)`. The helper `pipeline_commands_per_second()` reports approximate throughput.
+Use `pipeline_init_stages(&p, decode, prepare, dispatch)` to control the number of worker threads per stage or call the legacy `pipeline_init(&p, dispatch)` for a simple setup. After initialisation call `pipeline_start(&p)` to begin processing. When done, call `pipeline_stop(&p)` followed by `pipeline_join(&p)`. The helper `pipeline_commands_per_second()` reports approximate throughput.
 
 See `examples/replay_runtime.c` for a usage example.
 
@@ -178,6 +178,11 @@ $ ./bench_tests ../tests/fixtures 100000
 ```
 
 The second argument controls the number of iterations (default is 100000).
+
+To profile the runtime pipeline with different thread counts use
+`tools/gen_thruput.py`.  The script searches multiple decode/prepare/dispatch
+thread combinations, runs the best setup for one million iterations and writes
+the results plus host information to `THRUPUT.md`.
 
 ---
 

--- a/THRUPUT.md
+++ b/THRUPUT.md
@@ -1,0 +1,22 @@
+**Host**: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz (x86_64, 5 CPUs)
+**Best configuration**: decode=1 prepare=1 dispatch=2
+
+| Shader | Cmds/s |
+|-------|-------:|
+| mov_tex | 817915.44 |
+| mul_const | 1235479.83 |
+| dp3_matrix | 953910.06 |
+| add | 1200614.18 |
+| matrix_ops | 30888687.78 |
+| tex_ops | 920261.87 |
+| terrain_ps | 62238237.64 |
+| motion_blur_vs | 8795750.01 |
+| river_water_ps | 1064780.31 |
+| water_reflection_ps | 93629688.78 |
+| water_trapezoid_ps | 85683921.78 |
+| max_min | 1213959.72 |
+| cnd | 1138842.37 |
+| nop | 0.00 |
+| ps13_ops | 122196788.49 |
+| tex_matrix | 1899035.12 |
+| **Overall** | 2249874.83 |

--- a/examples/replay_runtime.c
+++ b/examples/replay_runtime.c
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
     }
 
     pipeline p;
-    if (pipeline_init(&p, threads) || pipeline_start(&p)) {
+    if (pipeline_init_stages(&p, 1, 1, threads) || pipeline_start(&p)) {
         fprintf(stderr, "pipeline init failed\n");
         free(src);
         return 1;

--- a/include/runtime_pipeline.h
+++ b/include/runtime_pipeline.h
@@ -3,6 +3,7 @@
 
 #include "minithread.h"
 #include "lf_queue.h"
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,16 +21,29 @@ typedef struct pipeline {
     lf_queue decode_q;
     lf_queue prepare_q;
     lf_queue dispatch_q;
-    int num_threads;
+    int decode_threads;
+    int prepare_threads;
+    int num_threads; /* dispatch threads */
     struct pipeline_stats *stats;
 } pipeline;
 
 double pipeline_commands_per_second(const pipeline *p);
 
 int pipeline_init(pipeline *p, int num_threads);
+int pipeline_init_stages(pipeline *p, int decode_threads, int prepare_threads,
+                         int dispatch_threads);
 int pipeline_start(pipeline *p);
 void pipeline_stop(pipeline *p);
 void pipeline_join(pipeline *p);
+
+static inline double ts_diff(const struct timespec *restrict s,
+                             const struct timespec *restrict e) {
+    return (e->tv_sec - s->tv_sec) + (e->tv_nsec - s->tv_nsec) / 1e9;
+}
+
+#define TS_DIFF(s, e)                                                         \
+    _Generic((s), struct timespec *: ts_diff, const struct timespec *: ts_diff)( \
+        (s), (e))
 
 #ifdef __cplusplus
 }

--- a/tools/gen_thruput.py
+++ b/tools/gen_thruput.py
@@ -1,0 +1,69 @@
+import subprocess
+import re
+import platform
+from pathlib import Path
+
+BUILD_DIR = Path(__file__).resolve().parent.parent / 'build'
+
+
+def host_spec() -> str:
+    """Return a short description of the host CPU."""
+    try:
+        out = subprocess.check_output(['lscpu'], text=True)
+        model = re.search(r'Model name:\s+(.+)', out)
+        arch = re.search(r'Architecture:\s+(.+)', out)
+        cpus = re.search(r'CPU\(s\):\s+(\d+)', out)
+        if model and arch and cpus:
+            return f"{model.group(1)} ({arch.group(1)}, {cpus.group(1)} CPUs)"
+    except Exception:
+        pass
+    u = platform.uname()
+    return f"{u.system} {u.machine} {u.processor}".strip()
+
+def run_bench(dec, prep, disp, iters=1000):
+    cmd = [
+        './bench_tests',
+        '../tests/fixtures',
+        str(iters),
+        '-stage1',
+        str(dec),
+        '-stage2',
+        str(prep),
+        '-stage3',
+        str(disp),
+    ]
+    res = subprocess.run(cmd, cwd=BUILD_DIR, text=True, capture_output=True)
+    return res.stdout
+
+def measure(dec, prep, disp):
+    out = run_bench(dec, prep, disp)
+    m = re.search(r'Overall: ([0-9.]+) cmds/s', out)
+    return float(m.group(1)) if m else 0.0
+
+best = (0.0, 1, 1, 1)
+for d in (1, 2, 3):
+    for p in (1, 2, 3):
+        for t in (1, 2, 3):
+            cps = measure(d, p, t)
+            if cps > best[0]:
+                best = (cps, d, p, t)
+
+output = run_bench(best[1], best[2], best[3], 1000000)
+
+pattern = re.compile(r'^(\w+): ([0-9.]+) cmds/s$', re.MULTILINE)
+rows = [(n, c) for (n, c) in pattern.findall(output) if n != 'Overall']
+overall = re.search(r'Overall: ([0-9.]+) cmds/s', output)
+
+md_lines = [f"**Host**: {host_spec()}",
+            f"**Best configuration**: decode={best[1]} prepare={best[2]} dispatch={best[3]}",
+            "",
+            "| Shader | Cmds/s |",
+            "|-------|-------:|"]
+for name, cps in rows:
+    md_lines.append(f"| {name} | {cps} |")
+if overall:
+    md_lines.append(f"| **Overall** | {overall.group(1)} |")
+
+(Path(__file__).resolve().parent.parent / 'THRUPUT.md').write_text("\n".join(md_lines) + "\n")
+print(f"Best combo: decode={best[1]} prepare={best[2]} dispatch={best[3]}")
+print('\n'.join(md_lines))


### PR DESCRIPTION
## Summary
- document throughput benchmark script
- include host info and best thread counts in THRUPUT.md
- update `gen_thruput.py` to record host specs and optimal stage threads

## Testing
- `cmake --build build`
- `ctest -V --test-dir build`
- `python tools/gen_thruput.py`


------
https://chatgpt.com/codex/tasks/task_e_68574b8d110483258f44c052f90160cf